### PR TITLE
Remove some unnecessary rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.swp

--- a/Sniffs/Array/ArrayDeclarationSniff.php
+++ b/Sniffs/Array/ArrayDeclarationSniff.php
@@ -492,7 +492,7 @@ class Framgia_Sniffs_Array_ArrayDeclarationSniff implements PHP_CodeSniffer_Snif
             // Array cannot be empty, so this is a multi-line array with
             // a single value. It should be defined on single line.
             $error = 'Multi-line array contains a single value; use single-line array instead';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MultiLineNotAllowed');
+            $fix   = $phpcsFile->addWarning($error, $stackPtr, 'MultiLineNotAllowed');
 
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -6,13 +6,9 @@
  <rule ref="PSR2"/>
  <rule ref="Squiz.WhiteSpace.CastSpacing"/>
  <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
- <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace"/>
  <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
- <rule ref="Squiz.WhiteSpace.FunctionSpacing"/>
  <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
  <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
- <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing"/>
- <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 
  <rule ref="./Sniffs/Array/ArrayDeclarationSniff.php"/>
  <rule ref="./Sniffs/String/DoubleQuoteUsageSniff.php"/>


### PR DESCRIPTION
- [x] Consider `MultiLineNotAllowed` as warning
- [x] Remove `Squiz.WhiteSpace.FunctionClosingBraceSpace` because we don't add blank line before closing brace
- [x] Remove `FunctionSpacing` because it doesn't handle closing brace of the last function in a class
- [x] Remove `ObjectOperatorSpacing` because sometimes we need space before `->` (Check example below)
- [x] Remove `SemicolonSpacing` because sometime we write `;` in new line  (Check example below)

``` php
$user = $this->userRepository
    ->where('name', 'foo')
    ->get()
;
```
